### PR TITLE
Process multiline commits.

### DIFF
--- a/internal/commands/cmd_pr.go
+++ b/internal/commands/cmd_pr.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/altipla-consulting/ci/internal/login"
 	"github.com/altipla-consulting/ci/internal/pr"
-	"github.com/altipla-consulting/ci/internal/prompt"
 	"github.com/altipla-consulting/ci/internal/query"
 	"github.com/altipla-consulting/ci/internal/run"
 )
@@ -77,13 +77,13 @@ var cmdPR = &cobra.Command{
 		if err != nil {
 			return errors.Trace(err)
 		}
+		parts := strings.SplitN(last, "\n\n", 2)
 
-		fmt.Println()
-		title, err := prompt.TextDefault("Título del PR", last)
-		if err != nil {
-			return errors.Trace(err)
+		var body string
+		if len(parts) > 1 {
+			body = parts[1]
 		}
-		link, err := pr.Create(ctx, title)
+		link, err := pr.Create(ctx, parts[0], body)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/internal/pr/pr.go
+++ b/internal/pr/pr.go
@@ -56,7 +56,7 @@ func ListBranches(ctx context.Context) ([]string, error) {
 	return names, nil
 }
 
-func Create(ctx context.Context, title string) (string, error) {
+func Create(ctx context.Context, title, body string) (string, error) {
 	if err := initClient(ctx); err != nil {
 		return "", errors.Trace(err)
 	}
@@ -82,7 +82,7 @@ func Create(ctx context.Context, title string) (string, error) {
 		Title: github.String(title),
 		Head:  github.String(branch),
 		Base:  github.String(base),
-		Body:  github.String(""),
+		Body:  github.String(body),
 	}
 	pr, _, err := client.PullRequests.Create(ctx, org, repo, req)
 	if err != nil {


### PR DESCRIPTION
To ignore descriptions added in the commit message.